### PR TITLE
feat: Update package.json in generated packages

### DIFF
--- a/build/packages/package.json.tpl
+++ b/build/packages/package.json.tpl
@@ -1,7 +1,11 @@
 {
   "name": "@prodemos/##PACKAGE-NAME##",
-  "repository": "https://github.com/prodemos/pds",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/prodemos/pds.git"
+  },
   "publishConfig": {
     "registry": "https://npm.pkg.github.com"
-  }
+  },
+  "scripts": {}
 }


### PR DESCRIPTION
when releasing, npm warned

```
npm WARN publish errors corrected:
npm WARN publish Removed invalid "scripts"
npm WARN publish "repository" was changed from a string to an object
npm WARN publish "repository.url" was normalized to "git+https://github.com/prodemos/pds.git"
```

`Removed invalid "scripts"` was a bogus warning, it requires scripts.